### PR TITLE
Resolving compiler warnings

### DIFF
--- a/Sources/CommandKit/Extensions/ArrayExtensions.swift
+++ b/Sources/CommandKit/Extensions/ArrayExtensions.swift
@@ -28,7 +28,7 @@ extension Array where Element == String {
             }
             else if element.hasPrefix("-") {
                 // Option
-                var newValue = element.replacingOccurrences(of: "-", with: "")
+                let newValue = element.replacingOccurrences(of: "-", with: "")
                 let newArg = Argument(value: newValue, type: .option)
                 argumentsToReturn.append(newArg)
             }

--- a/Sources/CommandKit/Extensions/StringExtensions.swift
+++ b/Sources/CommandKit/Extensions/StringExtensions.swift
@@ -29,7 +29,7 @@ extension String {
      
          Detemines if a string can be transformed to an object by the closure given
      */
-    internal func isConvertible(by transform: (String)->Any) -> Bool {
+    internal func isConvertible(by transform: StringTransform) -> Bool {
         return transform(self) != nil ? true : false
     }
     

--- a/Sources/CommandKit/Extensions/StringExtensions.swift
+++ b/Sources/CommandKit/Extensions/StringExtensions.swift
@@ -39,7 +39,7 @@ extension String {
         // Early escape condition
         guard numberOfLines >= 1 else { return self }
         
-        var stringSegments = self.segmentString(width: width)
+        let stringSegments = self.segmentString(width: width)
         return self.assembleLinedString(with: stringSegments, returnIndent: returnIndent)
     }
     
@@ -108,12 +108,7 @@ extension String {
         }
         let insertion = newLineChar + indent + "\t"
         
-        segments.count
-        
-        for (index, range) in segments.enumerated() {
-            self.distance(from: startIndex, to: range.lowerBound)
-            self.distance(from: startIndex, to: range.upperBound)
-            
+        for (index, range) in segments.enumerated() {            
             if index < (segments.count - 1) {
                 stringToReturn += self[range] + insertion
             }


### PR DESCRIPTION
Fixed a number of compiler warnings and resolved an inconsistency between StringTransform and some instances of where it was used that resulted in some implicit coercion. Also simplified code for getting remaining arguments. 